### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ before_install:
   - chmod 600 ~/.ssh/deploy_key
 after_script:
   - ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no  $USER_NAME@$SERVER_IP 'bash ~/biliob_backend/deploy.sh'
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.